### PR TITLE
Fix

### DIFF
--- a/boson-graviton-spring-boot-autoconfigure/src/main/java/io/github/cgglyle/boson/graviton/autoconfigure/GravitonAutoconfigure.java
+++ b/boson-graviton-spring-boot-autoconfigure/src/main/java/io/github/cgglyle/boson/graviton/autoconfigure/GravitonAutoconfigure.java
@@ -96,8 +96,8 @@ public class GravitonAutoconfigure {
     @ConditionalOnMissingBean
     @ConditionalOnNotWebApplication
     @Bean
-    LogControllerService logControllerService(@Nullable LogUserService logUserService) {
-        return new DefaultLogControllerServiceImpl(logUserService);
+    LogControllerService logControllerService(@Nullable LogUserService logUserService, GravitonLogInfoSpEL gravitonLogInfoSpEL) {
+        return new DefaultLogControllerServiceImpl(logUserService, gravitonLogInfoSpEL);
     }
 
     /**
@@ -106,8 +106,8 @@ public class GravitonAutoconfigure {
     @ConditionalOnMissingBean
     @ConditionalOnWebApplication
     @Bean
-    LogControllerService webLogControllerService(@Nullable LogUserService logUserService) {
-        return new DefaultWebLogControllerServiceImpl(logUserService);
+    LogControllerService webLogControllerService(@Nullable LogUserService logUserService, GravitonLogInfoSpEL gravitonLogInfoSpEL) {
+        return new DefaultWebLogControllerServiceImpl(logUserService, gravitonLogInfoSpEL);
     }
 
     /**

--- a/boson-graviton-spring-boot-test/src/main/java/io/github/cgglyle/boson/graviton/test/config/GravitonConfig.java
+++ b/boson-graviton-spring-boot-test/src/main/java/io/github/cgglyle/boson/graviton/test/config/GravitonConfig.java
@@ -40,8 +40,8 @@ public class GravitonConfig {
     }
 
     @Bean
-    LogControllerService logControllerService(@Nullable LogUserService logUserService) {
-        return new DefaultWebLogControllerServiceImpl(logUserService);
+    LogControllerService logControllerService(@Nullable LogUserService logUserService, GravitonLogInfoSpEL gravitonLogInfoSpEL) {
+        return new DefaultWebLogControllerServiceImpl(logUserService, gravitonLogInfoSpEL);
     }
 
     @Bean

--- a/boson-graviton-spring-boot-test/src/main/java/io/github/cgglyle/boson/graviton/test/controller/TestController.java
+++ b/boson-graviton-spring-boot-test/src/main/java/io/github/cgglyle/boson/graviton/test/controller/TestController.java
@@ -36,26 +36,28 @@ public class TestController {
 
     private final TestService service;
 
-    @GravitonLog(success = "Controoler 操作人 #{#userName} 将 #{#testContext} 变更为 #{#str} #{#root.methodName}, #{#result}",
-            failure = "Controoler 操作人 #{#userName} 将 #{#testContext} 变更为 #{#str} 操作失败")
+    @GravitonLog(success = "Controoler 操作人 #{#username} 将 #{#testContext} 变更为 #{#str} #{#root.methodName}, #{#result}",
+            failure = "Controoler 操作人 #{#username} 将 #{#testContext} 变更为 #{#str} 操作失败, 失败原因#{#errorMsg}")
     @ResponseBody
     @GetMapping("test/{str}")
     public String test(@PathVariable String str) {
-        GravitonLogContext.putVariable("username", "小王");
-        GravitonLogContext.putVariable("testContext", "测试Context");
+        GravitonLogContext.createLogContext();
+        GravitonLogContext.putVariable("username", "testController 小王");
+        GravitonLogContext.putVariable("testContext", "testController OK!");
         if (str.equals("cException")) {
             throw new RuntimeException("graviton test controller exception");
         }
         return service.testString(str) + " controller test";
     }
 
-    @GravitonLog(success = "Controoler 操作人 #{#userName} 将 #{#testContext} 变更为 #{#str} #{#root.methodName}, #{#result.username}",
-            failure = "Controoler 操作人 #{#userName} 将 #{#testContext} 变更为 #{#str} 操作失败")
+    @GravitonLog(success = "Controoler 操作人 #{#username} 将 #{#testContext} 变更为 #{#str} #{#root.methodName}, #{#result.username}",
+            failure = "Controoler 操作人 #{#username} 将 #{#testContext} 变更为 #{#str} 操作失败, 失败原因#{#errorMsg}")
     @ResponseBody
     @GetMapping("test/obj/{str}")
     public TestEntity testObj(@PathVariable String str) {
-        GravitonLogContext.putVariable("username", "小王");
-        GravitonLogContext.putVariable("testContext", "测试Context");
+        GravitonLogContext.createLogContext();
+        GravitonLogContext.putVariable("username", "testObjController 小王");
+        GravitonLogContext.putVariable("testContext", "testObjController OK!");
         TestEntity testEntity = new TestEntity();
         testEntity.setUsername(str);
         testEntity.setPassword("123456");

--- a/boson-graviton-spring-boot-test/src/main/java/io/github/cgglyle/boson/graviton/test/controller/TestController.java
+++ b/boson-graviton-spring-boot-test/src/main/java/io/github/cgglyle/boson/graviton/test/controller/TestController.java
@@ -18,6 +18,8 @@ package io.github.cgglyle.boson.graviton.test.controller;
 
 import io.github.cgglyle.boson.graviton.annotaion.EnableGravitonOrderNo;
 import io.github.cgglyle.boson.graviton.annotaion.GravitonLog;
+import io.github.cgglyle.boson.graviton.service.GravitonLogContext;
+import io.github.cgglyle.boson.graviton.test.entity.TestEntity;
 import io.github.cgglyle.boson.graviton.test.service.TestService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -34,14 +36,29 @@ public class TestController {
 
     private final TestService service;
 
-    @GravitonLog(success = "操作人 #{#userName} 将 #{#testContext} 变更为 #{#str} #{#root.methodName}, #{#result}",
-            failure = "操作人 #{#userName} 将 #{#testContext} 变更为 #{#str} 操作失败")
+    @GravitonLog(success = "Controoler 操作人 #{#userName} 将 #{#testContext} 变更为 #{#str} #{#root.methodName}, #{#result}",
+            failure = "Controoler 操作人 #{#userName} 将 #{#testContext} 变更为 #{#str} 操作失败")
     @ResponseBody
     @GetMapping("test/{str}")
     public String test(@PathVariable String str) {
+        GravitonLogContext.putVariable("username", "小王");
+        GravitonLogContext.putVariable("testContext", "测试Context");
         if (str.equals("cException")) {
             throw new RuntimeException("graviton test controller exception");
         }
         return service.testString(str) + " controller test";
+    }
+
+    @GravitonLog(success = "Controoler 操作人 #{#userName} 将 #{#testContext} 变更为 #{#str} #{#root.methodName}, #{#result.username}",
+            failure = "Controoler 操作人 #{#userName} 将 #{#testContext} 变更为 #{#str} 操作失败")
+    @ResponseBody
+    @GetMapping("test/obj/{str}")
+    public TestEntity testObj(@PathVariable String str) {
+        GravitonLogContext.putVariable("username", "小王");
+        GravitonLogContext.putVariable("testContext", "测试Context");
+        TestEntity testEntity = new TestEntity();
+        testEntity.setUsername(str);
+        testEntity.setPassword("123456");
+        return service.testObj(testEntity);
     }
 }

--- a/boson-graviton-spring-boot-test/src/main/java/io/github/cgglyle/boson/graviton/test/entity/TestEntity.java
+++ b/boson-graviton-spring-boot-test/src/main/java/io/github/cgglyle/boson/graviton/test/entity/TestEntity.java
@@ -14,16 +14,18 @@
  * limitations under the License.
  */
 
-package io.github.cgglyle.boson.graviton.test.service;
+package io.github.cgglyle.boson.graviton.test.entity;
 
-import io.github.cgglyle.boson.graviton.test.entity.TestEntity;
+import lombok.Data;
+import lombok.ToString;
 
 /**
  * @author Lyle
- * @since 2022/09/17
+ * @since 2022/10/09
  */
-public interface TestService {
-    String testString(String str);
-
-    TestEntity testObj(TestEntity entity);
+@Data
+@ToString
+public class TestEntity {
+    private String username;
+    private String password;
 }

--- a/boson-graviton-spring-boot-test/src/main/java/io/github/cgglyle/boson/graviton/test/service/TestServiceImpl.java
+++ b/boson-graviton-spring-boot-test/src/main/java/io/github/cgglyle/boson/graviton/test/service/TestServiceImpl.java
@@ -16,8 +16,10 @@
 
 package io.github.cgglyle.boson.graviton.test.service;
 
+import io.github.cgglyle.boson.graviton.annotaion.EnableGravitonOrderNo;
 import io.github.cgglyle.boson.graviton.annotaion.GravitonLog;
 import io.github.cgglyle.boson.graviton.service.GravitonLogContext;
+import io.github.cgglyle.boson.graviton.test.entity.TestEntity;
 import org.springframework.stereotype.Service;
 
 /**
@@ -25,11 +27,12 @@ import org.springframework.stereotype.Service;
  * @since 2022/09/17
  */
 @Service
+@EnableGravitonOrderNo
 public class TestServiceImpl implements TestService {
 
     @Override
-    @GravitonLog(success = "操作人 #{#userName} 将 #{#testContext} 变更为 #{#str} #{#root.methodName}, #{#result}",
-            failure = "操作人 #{#userName} 将 #{#testContext} 变更为 #{#str} 操作失败")
+    @GravitonLog(success = "Service 操作人 #{#userName} 将 #{#testContext} 变更为 #{#str} #{#root.methodName}, #{#result}",
+            failure = "Service 操作人 #{#userName} 将 #{#testContext} 变更为 #{#str} 操作失败")
     public String testString(String str) {
         GravitonLogContext.putVariable("testContext", str + "OK!");
         GravitonLogContext.putVariable("userName", str + "小王");
@@ -37,5 +40,12 @@ public class TestServiceImpl implements TestService {
             throw new RuntimeException("graviton test service exception");
         }
         return str;
+    }
+
+    @Override
+    @GravitonLog(success = "Service 操作人 #{#userName} 将 #{#testContext} 变更为 #{#str} #{#root.methodName}, #{#result.username}",
+            failure = "Service 操作人 #{#userName} 将 #{#testContext} 变更为 #{#str} 操作失败")
+    public TestEntity testObj(TestEntity entity) {
+        return entity;
     }
 }

--- a/boson-graviton-spring-boot-test/src/main/java/io/github/cgglyle/boson/graviton/test/service/TestServiceImpl.java
+++ b/boson-graviton-spring-boot-test/src/main/java/io/github/cgglyle/boson/graviton/test/service/TestServiceImpl.java
@@ -31,11 +31,12 @@ import org.springframework.stereotype.Service;
 public class TestServiceImpl implements TestService {
 
     @Override
-    @GravitonLog(success = "Service 操作人 #{#userName} 将 #{#testContext} 变更为 #{#str} #{#root.methodName}, #{#result}",
-            failure = "Service 操作人 #{#userName} 将 #{#testContext} 变更为 #{#str} 操作失败")
+    @GravitonLog(success = "Service 操作人 #{#username} 将 #{#testContext} 变更为 #{#str} #{#root.methodName}, #{#result}",
+            failure = "Service 操作人 #{#username} 将 #{#testContext} 变更为 #{#str} 操作失败, 失败原因#{#errorMsg}")
     public String testString(String str) {
+        GravitonLogContext.createLogContext();
         GravitonLogContext.putVariable("testContext", str + "OK!");
-        GravitonLogContext.putVariable("userName", str + "小王");
+        GravitonLogContext.putVariable("username", "testStringService 小王");
         if (str.equals("sException")) {
             throw new RuntimeException("graviton test service exception");
         }
@@ -43,9 +44,12 @@ public class TestServiceImpl implements TestService {
     }
 
     @Override
-    @GravitonLog(success = "Service 操作人 #{#userName} 将 #{#testContext} 变更为 #{#str} #{#root.methodName}, #{#result.username}",
-            failure = "Service 操作人 #{#userName} 将 #{#testContext} 变更为 #{#str} 操作失败")
+    @GravitonLog(success = "Service 操作人 #{#username} 将 #{#testContext} 变更为 #{#str} #{#root.methodName}, #{#result.username}",
+            failure = "Service 操作人 #{#username} 将 #{#testContext} 变更为 #{#str} 操作失败, 失败原因#{#errorMsg}")
     public TestEntity testObj(TestEntity entity) {
+        GravitonLogContext.createLogContext();
+        GravitonLogContext.putVariable("testContext", "testObjService OK!");
+//        GravitonLogContext.putVariable("username", "testObjService 小王");
         return entity;
     }
 }

--- a/boson-graviton-spring-boot-test/src/main/java/io/github/cgglyle/boson/graviton/test/service/Username.java
+++ b/boson-graviton-spring-boot-test/src/main/java/io/github/cgglyle/boson/graviton/test/service/Username.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 Cgglyle
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.cgglyle.boson.graviton.test.service;
+
+import io.github.cgglyle.boson.graviton.api.LogUserService;
+import org.springframework.stereotype.Service;
+
+/**
+ * @author Lyle
+ * @since 2022/10/10
+ */
+@Service
+public class Username implements LogUserService {
+    @Override
+    public String getUsername() {
+        return "LogUserService 小张";
+    }
+}

--- a/boson-graviton-spring-boot/pom.xml
+++ b/boson-graviton-spring-boot/pom.xml
@@ -27,6 +27,16 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-aop</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-test-autoconfigure</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/boson-graviton-spring-boot/pom.xml
+++ b/boson-graviton-spring-boot/pom.xml
@@ -27,16 +27,6 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-aop</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-test-autoconfigure</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
 </project>

--- a/boson-graviton-spring-boot/src/main/java/io/github/cgglyle/boson/graviton/annotaion/GravitonLog.java
+++ b/boson-graviton-spring-boot/src/main/java/io/github/cgglyle/boson/graviton/annotaion/GravitonLog.java
@@ -18,8 +18,8 @@ package io.github.cgglyle.boson.graviton.annotaion;
 
 
 import io.github.cgglyle.boson.graviton.api.OrderNoGenerate;
-import io.github.cgglyle.boson.graviton.service.UUIDOrderNo;
 import io.github.cgglyle.boson.graviton.model.LogInfo;
+import io.github.cgglyle.boson.graviton.service.UUIDOrderNo;
 import org.springframework.core.annotation.AliasFor;
 
 import java.lang.annotation.*;
@@ -76,7 +76,10 @@ public @interface GravitonLog {
     /**
      * 业务日志
      * <p>
-     * 支持SpEL
+     * 支持SpEL, SpEl 使用 "#{}" 作为模板，请按照下方示例编写SpEL语句
+     * <p>
+     * {@code @GravitonLog(success = "Service 操作人 #{#userName} 将 #{#testContext} 变更为 #{#str} #{#root.methodName},
+     * #{#result}")}
      */
     @AliasFor("value")
     String success() default "";
@@ -92,7 +95,9 @@ public @interface GravitonLog {
     /**
      * 业务失败日志
      * <p>
-     * 支持SpEL
+     * 支持SpEL, SpEl 使用 "#{}" 作为模板，请按照下方示例编写SpEL语句
+     * <p>
+     * {@code @GravitonLog(failure = "Service 操作人 #{#userName} 将 #{#testContext} 变更为 #{#str} 操作失败")
      */
     String failure() default "";
 

--- a/boson-graviton-spring-boot/src/main/java/io/github/cgglyle/boson/graviton/api/GravitonLogInfoSpEL.java
+++ b/boson-graviton-spring-boot/src/main/java/io/github/cgglyle/boson/graviton/api/GravitonLogInfoSpEL.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2022 Cgglyle
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.cgglyle.boson.graviton.api;
+
+import io.github.cgglyle.boson.graviton.model.LogInfo;
+import org.springframework.scheduling.annotation.Async;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * @author Lyle
+ * @since 2022/10/09
+ */
+public interface GravitonLogInfoSpEL {
+    @Async("gravitonLogPool")
+    CompletableFuture<?> parser(LogInfo loginfo, Class<?> parserResultClass);
+}

--- a/boson-graviton-spring-boot/src/main/java/io/github/cgglyle/boson/graviton/api/LogUserService.java
+++ b/boson-graviton-spring-boot/src/main/java/io/github/cgglyle/boson/graviton/api/LogUserService.java
@@ -26,6 +26,8 @@ public interface LogUserService {
 
     /**
      * 获取用户信息
+     * <p>
+     * 注意，此方法会较晚执行，SpEL在方法中的username上下文存入可能会被覆盖。
      */
-    String getUserName();
+    String getUsername();
 }

--- a/boson-graviton-spring-boot/src/main/java/io/github/cgglyle/boson/graviton/model/LogInfo.java
+++ b/boson-graviton-spring-boot/src/main/java/io/github/cgglyle/boson/graviton/model/LogInfo.java
@@ -18,9 +18,11 @@ package io.github.cgglyle.boson.graviton.model;
 
 import io.github.cgglyle.boson.graviton.api.LogControllerService;
 import lombok.Data;
+import org.aspectj.lang.JoinPoint;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * 日志信息
@@ -48,9 +50,15 @@ public class LogInfo {
     private boolean async;
     private boolean enableSystem;
     private boolean enableBusiness;
+    private boolean enableOrderNo;
     private String timeFormat;
     private String success;
     private String failure;
+    private Object systemLog;
+    private Object businessLog;
     private String orderNo;
     private String userName;
+    private JoinPoint joinPoint;
+    private String errorMsg;
+    private CompletableFuture<?> spELFuture;
 }

--- a/boson-graviton-spring-boot/src/main/java/io/github/cgglyle/boson/graviton/model/LogInfo.java
+++ b/boson-graviton-spring-boot/src/main/java/io/github/cgglyle/boson/graviton/model/LogInfo.java
@@ -57,7 +57,7 @@ public class LogInfo {
     private Object systemLog;
     private Object businessLog;
     private String orderNo;
-    private String userName;
+    private String username;
     private JoinPoint joinPoint;
     private String errorMsg;
     private CompletableFuture<?> spELFuture;

--- a/boson-graviton-spring-boot/src/main/java/io/github/cgglyle/boson/graviton/service/DefaultLogControllerServiceImpl.java
+++ b/boson-graviton-spring-boot/src/main/java/io/github/cgglyle/boson/graviton/service/DefaultLogControllerServiceImpl.java
@@ -16,12 +16,15 @@
 
 package io.github.cgglyle.boson.graviton.service;
 
+import io.github.cgglyle.boson.graviton.annotaion.EnableGravitonOrderNo;
 import io.github.cgglyle.boson.graviton.annotaion.GravitonLog;
+import io.github.cgglyle.boson.graviton.api.GravitonLogInfoSpEL;
 import io.github.cgglyle.boson.graviton.api.LogControllerService;
 import io.github.cgglyle.boson.graviton.api.LogUserService;
 import io.github.cgglyle.boson.graviton.model.LogInfo;
 import lombok.RequiredArgsConstructor;
 import org.aspectj.lang.JoinPoint;
+import org.springframework.core.annotation.AnnotationUtils;
 
 import java.util.Arrays;
 import java.util.List;
@@ -35,6 +38,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class DefaultLogControllerServiceImpl implements LogControllerService {
     private final LogUserService logUserService;
+    private final GravitonLogInfoSpEL logInfoSpEL;
 
     /**
      * 日志前置处理
@@ -59,7 +63,15 @@ public class DefaultLogControllerServiceImpl implements LogControllerService {
                 joinPoint.getSignature().getName());
         List<Object> objects = Arrays.asList(joinPoint.getArgs());
         logInfo.setInParameter(objects);
-        logInfo.setStatus(true);
+        logInfo.setSuccess(gravitonLog.success());
+        logInfo.setFailure(gravitonLog.failure());
+        logInfo.setJoinPoint(joinPoint);
+        EnableGravitonOrderNo annotation = AnnotationUtils.findAnnotation(joinPoint.getSignature().getDeclaringType(), EnableGravitonOrderNo.class);
+        if (annotation != null | gravitonLog.enableOrderNo()) {
+            logInfo.setEnableOrderNo(true);
+        } else {
+            logInfo.setBusinessLog(false);
+        }
     }
 
     /**
@@ -74,7 +86,9 @@ public class DefaultLogControllerServiceImpl implements LogControllerService {
      */
     @Override
     public void postprocessing(Object body, LogInfo logInfo) {
+        logInfo.setStatus(true);
         logInfo.setOutParameter(body);
+        logInfo.setSpELFuture(logInfoSpEL.parser(logInfo, Object.class));
     }
 
     /**
@@ -89,5 +103,6 @@ public class DefaultLogControllerServiceImpl implements LogControllerService {
     public void exceptionProcessing(Throwable throwable, LogInfo logInfo) {
         logInfo.setException(throwable);
         logInfo.setStatus(false);
+        logInfo.setSpELFuture(logInfoSpEL.parser(logInfo, Object.class));
     }
 }

--- a/boson-graviton-spring-boot/src/main/java/io/github/cgglyle/boson/graviton/service/DefaultLogControllerServiceImpl.java
+++ b/boson-graviton-spring-boot/src/main/java/io/github/cgglyle/boson/graviton/service/DefaultLogControllerServiceImpl.java
@@ -52,7 +52,7 @@ public class DefaultLogControllerServiceImpl implements LogControllerService {
     @Override
     public void preprocessing(JoinPoint joinPoint, GravitonLog gravitonLog, LogInfo logInfo) {
         if (logUserService != null) {
-            logInfo.setUserName(logUserService.getUserName());
+            logInfo.setUsername(logUserService.getUsername());
         }
         logInfo.setEnableSystem(gravitonLog.enableSystem());
         logInfo.setEnableBusiness(gravitonLog.enableBusiness());

--- a/boson-graviton-spring-boot/src/main/java/io/github/cgglyle/boson/graviton/service/DefaultLogPrintfServiceImpl.java
+++ b/boson-graviton-spring-boot/src/main/java/io/github/cgglyle/boson/graviton/service/DefaultLogPrintfServiceImpl.java
@@ -73,7 +73,7 @@ public class DefaultLogPrintfServiceImpl implements LogPrintfService {
                 }
             }
         }
-        if (logInfo.isEnableBusiness() && logInfo.getBusinessLog() != null && StringUtils.hasText(logInfo.getBusinessLog().toString())) {
+        if (logInfo.isEnableBusiness() && (StringUtils.hasText(logInfo.getSuccess()) && logInfo.isStatus()) || (StringUtils.hasText(logInfo.getFailure()) && !logInfo.isStatus())) {
             if (logInfo.getSpELFuture() != null) {
                 CompletableFuture.allOf(logInfo.getSpELFuture()).join();
             }

--- a/boson-graviton-spring-boot/src/main/java/io/github/cgglyle/boson/graviton/service/DefaultWebLogControllerServiceImpl.java
+++ b/boson-graviton-spring-boot/src/main/java/io/github/cgglyle/boson/graviton/service/DefaultWebLogControllerServiceImpl.java
@@ -68,7 +68,7 @@ public class DefaultWebLogControllerServiceImpl implements LogControllerService 
             }
         }
         if (logUserService != null) {
-            logInfo.setUserName(logUserService.getUserName());
+            logInfo.setUsername(logUserService.getUsername());
         }
         logInfo.setEnableSystem(gravitonLog.enableSystem());
         logInfo.setEnableBusiness(gravitonLog.enableBusiness());
@@ -121,6 +121,7 @@ public class DefaultWebLogControllerServiceImpl implements LogControllerService 
     @Override
     public void exceptionProcessing(Throwable throwable, LogInfo logInfo) {
         logInfo.setException(throwable);
+        logInfo.setErrorMsg(throwable.getMessage());
         logInfo.setStatus(false);
         if (StringUtils.hasText(logInfo.getFailure())) {
             GravitonLogContext.putVariable(logInfo);

--- a/boson-graviton-spring-boot/src/main/java/io/github/cgglyle/boson/graviton/service/DefaultWebLogControllerServiceImpl.java
+++ b/boson-graviton-spring-boot/src/main/java/io/github/cgglyle/boson/graviton/service/DefaultWebLogControllerServiceImpl.java
@@ -25,6 +25,7 @@ import io.github.cgglyle.boson.graviton.model.LogInfo;
 import lombok.RequiredArgsConstructor;
 import org.aspectj.lang.JoinPoint;
 import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.util.StringUtils;
 import org.springframework.web.context.request.RequestAttributes;
 import org.springframework.web.context.request.RequestContextHolder;
 
@@ -103,7 +104,10 @@ public class DefaultWebLogControllerServiceImpl implements LogControllerService 
     public void postprocessing(Object body, LogInfo logInfo) {
         logInfo.setStatus(true);
         logInfo.setOutParameter(body);
-        logInfo.setSpELFuture(logInfoSpEL.parser(logInfo, Object.class));
+        if (StringUtils.hasText(logInfo.getSuccess())) {
+            GravitonLogContext.putVariable(logInfo);
+            logInfo.setSpELFuture(logInfoSpEL.parser(logInfo, Object.class));
+        }
     }
 
     /**
@@ -118,6 +122,9 @@ public class DefaultWebLogControllerServiceImpl implements LogControllerService 
     public void exceptionProcessing(Throwable throwable, LogInfo logInfo) {
         logInfo.setException(throwable);
         logInfo.setStatus(false);
-        logInfo.setSpELFuture(logInfoSpEL.parser(logInfo, Object.class));
+        if (StringUtils.hasText(logInfo.getFailure())) {
+            GravitonLogContext.putVariable(logInfo);
+            logInfo.setSpELFuture(logInfoSpEL.parser(logInfo, Object.class));
+        }
     }
 }

--- a/boson-graviton-spring-boot/src/main/java/io/github/cgglyle/boson/graviton/service/GravitonLogExpressionEvaluator.java
+++ b/boson-graviton-spring-boot/src/main/java/io/github/cgglyle/boson/graviton/service/GravitonLogExpressionEvaluator.java
@@ -16,10 +16,8 @@
 
 package io.github.cgglyle.boson.graviton.service;
 
-import io.github.cgglyle.boson.graviton.api.LogUserService;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import org.springframework.aop.support.AopUtils;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.context.expression.AnnotatedElementKey;
@@ -27,7 +25,6 @@ import org.springframework.context.expression.BeanFactoryResolver;
 import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.Expression;
 import org.springframework.lang.Nullable;
-import org.springframework.stereotype.Service;
 
 import java.lang.reflect.Method;
 import java.util.Map;
@@ -39,17 +36,12 @@ import java.util.concurrent.ConcurrentHashMap;
  * @author Lyle
  * @since 2022/10/05
  */
-@RequiredArgsConstructor
-@Service
 public class GravitonLogExpressionEvaluator extends AbstractCachedTemplateExpressionEvaluator {
     private final Map<ExpressionKey, Expression> messageCache = new ConcurrentHashMap<>(64);
     private final Map<ExpressionKey, Expression> conditionCache = new ConcurrentHashMap<>(64);
     private final Map<ExpressionKey, Expression> unlessCache = new ConcurrentHashMap<>(64);
 
     private final Map<AnnotatedElementKey, Method> targetMethodCache = new ConcurrentHashMap<>(64);
-
-    @Nullable
-    private final LogUserService logUserService;
 
     /**
      * 解析指定表达式。

--- a/boson-graviton-spring-boot/src/main/java/io/github/cgglyle/boson/graviton/service/GravitonLogExpressionEvaluator.java
+++ b/boson-graviton-spring-boot/src/main/java/io/github/cgglyle/boson/graviton/service/GravitonLogExpressionEvaluator.java
@@ -71,7 +71,7 @@ public class GravitonLogExpressionEvaluator extends AbstractCachedTemplateExpres
             logEvaluationContext.setBeanResolver(new BeanFactoryResolver(beanFactory));
         }
         if (logUserService != null) {
-            logEvaluationContext.setVariable("userName", logUserService.getUserName());
+            logEvaluationContext.setVariable("username", logUserService.getUserName());
         }
         return logEvaluationContext;
     }

--- a/boson-graviton-spring-boot/src/main/java/io/github/cgglyle/boson/graviton/service/GravitonLogExpressionEvaluator.java
+++ b/boson-graviton-spring-boot/src/main/java/io/github/cgglyle/boson/graviton/service/GravitonLogExpressionEvaluator.java
@@ -70,9 +70,6 @@ public class GravitonLogExpressionEvaluator extends AbstractCachedTemplateExpres
         if (beanFactory != null) {
             logEvaluationContext.setBeanResolver(new BeanFactoryResolver(beanFactory));
         }
-        if (logUserService != null) {
-            logEvaluationContext.setVariable("username", logUserService.getUserName());
-        }
         return logEvaluationContext;
     }
 

--- a/boson-graviton-spring-boot/src/main/java/io/github/cgglyle/boson/graviton/service/GravitonLogInfoValueParser.java
+++ b/boson-graviton-spring-boot/src/main/java/io/github/cgglyle/boson/graviton/service/GravitonLogInfoValueParser.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2022 Cgglyle
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.cgglyle.boson.graviton.service;
+
+import io.github.cgglyle.boson.graviton.api.GravitonLogInfoSpEL;
+import io.github.cgglyle.boson.graviton.api.GravitonLogSpEL;
+import io.github.cgglyle.boson.graviton.model.LogInfo;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * @author Lyle
+ * @since 2022/10/09
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GravitonLogInfoValueParser implements GravitonLogInfoSpEL {
+    private final GravitonLogSpEL gravitonLogSpEl;
+
+    @Override
+    public CompletableFuture<?> parser(LogInfo loginfo, Class<?> parserResultClass) {
+        if (loginfo.isStatus()) {
+            try {
+                Object parser = gravitonLogSpEl.parser(loginfo.getJoinPoint(),
+                        loginfo.getSuccess().toString(), loginfo.getOutParameter(), null, parserResultClass);
+                loginfo.setBusinessLog(parser);
+            } catch (Exception e) {
+                log.error("SpEL解析出现异常" + e.getMessage(), e);
+            }
+        } else {
+            try {
+                Object parser = gravitonLogSpEl.parser(loginfo.getJoinPoint(),
+                        loginfo.getFailure().toString(), null, loginfo.getErrorMsg(), parserResultClass);
+                loginfo.setBusinessLog(parser);
+            } catch (Exception e) {
+                log.error("SpEL解析出现异常" + e.getMessage(), e);
+            }
+        }
+        return CompletableFuture.completedFuture(null);
+    }
+}

--- a/boson-graviton-spring-boot/src/main/java/io/github/cgglyle/boson/graviton/service/GravitonLogValueParser.java
+++ b/boson-graviton-spring-boot/src/main/java/io/github/cgglyle/boson/graviton/service/GravitonLogValueParser.java
@@ -19,7 +19,6 @@ package io.github.cgglyle.boson.graviton.service;
 import io.github.cgglyle.boson.graviton.api.GravitonLogSpEL;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.reflect.MethodSignature;
 import org.springframework.beans.BeansException;
@@ -29,7 +28,7 @@ import org.springframework.context.expression.AnnotatedElementKey;
 import org.springframework.expression.EvaluationContext;
 import org.springframework.lang.NonNull;
 import org.springframework.lang.Nullable;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 
 import java.lang.reflect.Method;
 import java.util.function.Supplier;
@@ -40,10 +39,9 @@ import java.util.function.Supplier;
  * @author Lyle
  * @since 2022/10/05
  */
-@Service
-@RequiredArgsConstructor
+@Component
 public class GravitonLogValueParser implements BeanFactoryAware, GravitonLogSpEL {
-    private final GravitonLogExpressionEvaluator logExpressionEvaluator;
+    private final GravitonLogExpressionEvaluator logExpressionEvaluator = new GravitonLogExpressionEvaluator();
     @Nullable
     private BeanFactory beanFactory;
 

--- a/boson-graviton-spring-boot/src/main/java/io/github/cgglyle/boson/graviton/service/TemplateInterpreter.java
+++ b/boson-graviton-spring-boot/src/main/java/io/github/cgglyle/boson/graviton/service/TemplateInterpreter.java
@@ -123,15 +123,6 @@ public class TemplateInterpreter {
                 throw new RuntimeException(e);
             }
         }
-        if (StringUtils.hasText(info.getOrderNo())) {
-            if (StringUtils.hasText(info.getSuccess())) {
-                info.setSuccess(info.getOrderNo() + info.getSuccess());
-            }
-            if (StringUtils.hasText(info.getFailure())) {
-                info.setFailure(info.getOrderNo() + info.getFailure());
-            }
-            return info.getOrderNo() + tempStr;
-        }
         return tempStr;
     }
 

--- a/boson-graviton-spring-boot/src/test/java/io/github/cgglyle/boson/graviton/service/TemplateInterpreterTest.java
+++ b/boson-graviton-spring-boot/src/test/java/io/github/cgglyle/boson/graviton/service/TemplateInterpreterTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2022 Cgglyle
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.cgglyle.boson.graviton.service;
+
+import io.github.cgglyle.boson.graviton.exception.LogException;
+import io.github.cgglyle.boson.graviton.model.LogInfo;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TemplateInterpreterTest {
+    private static final String SUCCESS_TEMPLATE = "[日志] [开始时间]=[{{startTime}}] " +
+            "[结束时间]=[{{endTime}}] [耗时]=[{{consumeTime}}ms] " +
+            "[URL]=[{{url}}] [URI]=[{{uri}}] " +
+            "[类名]=[{{className}}] [入参]=[{{inParameter}}] [出参]=[{{outParameter}}]";
+    private static final String FAILURE_TEMPLATE = "[日志] [开始时间]=[{{startTime}}] " +
+            "[结束时间]=[{{endTime}}] [耗时]=[{{consumeTime}}ms] " +
+            "[URL]=[{{url}}] [URI]=[{{uri}}] " +
+            "[类名]=[{{className}}] [入参]=[{{inParameter}}] [异常]=[{{exception}}]";
+    private static final String TIME_FORMAT = "yyyy-MM-dd HH:mm:ss.SSS";
+    private final LogInfo info = new LogInfo();
+    private TemplateInterpreter templateInterpreterUnderTest;
+
+    @BeforeEach
+    void setUp() {
+        templateInterpreterUnderTest = new TemplateInterpreter(SUCCESS_TEMPLATE, FAILURE_TEMPLATE, TIME_FORMAT);
+        TempInParameter tempInParameter = new TempInParameter("in parameter", "in value");
+        TempOutParameter tempOutParameter = new TempOutParameter("out parameter", "out value");
+        info.setStartTime(LocalDateTime.of(2020, 1, 1, 0, 0, 0));
+        info.setEndTime(LocalDateTime.of(2020, 1, 1, 0, 0, 5));
+        info.setConsumeTime(5L);
+        info.setUrl("url");
+        info.setUri("uri");
+        info.setClassName("className");
+        info.setInParameter(tempInParameter);
+        info.setOutParameter(tempOutParameter);
+        info.setException(new Exception("message"));
+        info.setSuccessTemplate("[日志] [开始时间]=[{{startTime}}]");
+        info.setFailureTemplate("[入参]=[{{inParameter}}] [异常]=[{{exception}}]");
+        info.setStatus(false);
+        info.setAsync(false);
+        info.setEnableSystem(false);
+        info.setTimeFormat("yyyy-MM-dd");
+    }
+
+    @Test
+    void testInterpreter_normalStatus() {
+        // Setup
+        info.setStatus(true);
+        // Run the test
+        final String result = templateInterpreterUnderTest.interpreter(info);
+
+        // Verify the results
+        assertThat(result).isEqualTo("[日志] [开始时间]=[2020-01-01]");
+    }
+
+    @Test
+    void testInterpreter_exceptionStatus() {
+        // Setup
+        info.setStatus(false);
+        // Run the test
+        final String result = templateInterpreterUnderTest.interpreter(info);
+
+        // Verify the results
+        assertThat(result).isEqualTo("[入参]=[TemplateInterpreterTest.TempInParameter(name=in parameter, value=in value)] [异常]=[java.lang.Exception: message]");
+    }
+
+    @Test
+    void testInterpreter_noSuccessTemplate() {
+        // Setup
+        info.setStatus(true);
+        info.setSuccessTemplate(null);
+        // Run the test
+        final String result = templateInterpreterUnderTest.interpreter(info);
+
+        // Verify the results
+        assertThat(result).isEqualTo("[日志] [开始时间]=[2020-01-01] [结束时间]=[2020-01-01] [耗时]=[5ms] [URL]=[url] [URI]=[uri] [类名]=[className] [入参]=[TemplateInterpreterTest.TempInParameter(name=in parameter, value=in value)] [出参]=[TemplateInterpreterTest.TempOutParameter(name=out parameter, value=out value)]");
+    }
+
+    @Test
+    void testInterpreter_noFailureTemplate() {
+        // Setup
+        info.setStatus(false);
+        info.setFailureTemplate(null);
+        // Run the test
+        final String result = templateInterpreterUnderTest.interpreter(info);
+
+        // Verify the results
+        assertThat(result).isEqualTo("[日志] [开始时间]=[2020-01-01] [结束时间]=[2020-01-01] [耗时]=[5ms] [URL]=[url] [URI]=[uri] [类名]=[className] [入参]=[TemplateInterpreterTest.TempInParameter(name=in parameter, value=in value)] [异常]=[java.lang.Exception: message]");
+    }
+
+    @Test
+    void testInterpreter_noParams() {
+        info.setStatus(true);
+        info.setSuccessTemplate("{{test}}");
+        Assertions.assertThrows(LogException.class, () -> templateInterpreterUnderTest.interpreter(info), "预期返回LogException异常");
+    }
+
+    @Test
+    void testInterpreter_noParamsTemplate() {
+        info.setStartTime(null);
+        info.setStatus(true);
+
+        // Run the test
+        final String result = templateInterpreterUnderTest.interpreter(info);
+
+        // Verify the results
+        assertThat(result).isEqualTo("[日志] [开始时间]=[null]");
+    }
+
+    @Data
+    @AllArgsConstructor
+    private class TempInParameter {
+        private String name;
+        private String value;
+    }
+
+    @Data
+    @AllArgsConstructor
+    private class TempOutParameter {
+        private String name;
+        private String value;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,11 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-test-autoconfigure</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <profiles>


### PR DESCRIPTION
## 变化
- 打印模块现在是完全异步的，并将OrderNo移动至此
- SpEL解析失败只会打印错误日志，不再会打断进程
- [修复了线程等待造成的业务日志不打印](https://github.com/cgglyle/boson-graviton/commit/d23642569911f208eda2b153e5309b2196230612)
- [refactor: 现在核心A](https://github.com/cgglyle/boson-graviton/commit/9a0fecaba101d8a71fce573132ff90ced16c2b06)